### PR TITLE
Fixed a bug and added a test clause for it

### DIFF
--- a/knncmi/knncmi.py
+++ b/knncmi/knncmi.py
@@ -141,7 +141,7 @@ def cmi(x, y, z, k, data, discrete_dist = 1, minzero = 1):
     # convert variable to index if not already
     vrbls = [x,y,z]
     for i, lst in enumerate(vrbls):
-        if all(type(elem) == str for elem in lst) & len(lst) > 0:
+        if all(type(elem) == str for elem in lst) and len(lst) > 0:
             vrbls[i] = list(data.columns.get_indexer(lst))
     x,y,z = vrbls
             

--- a/tests/test_knncmi.py
+++ b/tests/test_knncmi.py
@@ -365,6 +365,8 @@ class test_class(unittest.TestCase):
         out = cmi(['slength'], ['swidth'], ['class'], 3, data)
         self.assertLessEqual(np.abs(out), 2 * digamma(n))
 
+        cmi(['slength'], ['swidth'], ['class','plength'], 3, data)
+
         out = cmi(['class'], ['swidth'], [], 3, data)
         self.assertLessEqual(out, 2 * digamma(n))
 


### PR DESCRIPTION
There is a bug in the current code, so that when having multiple string indices, they do not get converted to a integer list of indices. There is no test case to find the bug.

So I corrected the mistake `&` to a `and`, and wrote a test line for it.