### PR TITLE
fixed case when dtypes are not numpy types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -415,6 +415,9 @@ pythontex-files-*/
 TSWLatexianTemp*
 
 ## Editors:
+# VS Code
+.vscode
+
 # WinEdt
 *.bak
 *.sav

--- a/knncmi/knncmi.py
+++ b/knncmi/knncmi.py
@@ -27,12 +27,15 @@ def getPairwiseDistArray(data, coords = [], discrete_dist = 1):
     distArray = np.empty([p,n,n])
     distArray[:] = np.nan
     for coord in coords:
-        if np.issubdtype(data[col_names[coord]].dtype, np.number):
-            distArray[coord,:,:] = abs(data[col_names[coord]].values -
-                                       data[col_names[coord]].values[:,None])
+        thisdtype=data[col_names[coord]].dtype
+        is_numerical = (isinstance(thisdtype, np.dtype) 
+            and np.issubdtype(thisdtype, np.number))
+        if is_numerical:
+            distArray[coord,:,:] = abs(data[col_names[coord]].to_numpy() -
+                                       data[col_names[coord]].to_numpy()[:,None])
         else:
-            distArray[coord,:,:] = (1 - (data[col_names[coord]].values ==
-                                    data[col_names[coord]].values[:,None])) * discrete_dist
+            distArray[coord,:,:] = (1 - (data[col_names[coord]].to_numpy() ==
+                                    data[col_names[coord]].to_numpy()[:,None])) * discrete_dist
     return distArray
 
 def getPointCoordDists(distArray, ind_i, coords = list()):

--- a/knncmi/knncmi.py
+++ b/knncmi/knncmi.py
@@ -28,9 +28,7 @@ def getPairwiseDistArray(data, coords = [], discrete_dist = 1):
     distArray[:] = np.nan
     for coord in coords:
         thisdtype=data[col_names[coord]].dtype
-        is_numerical = (isinstance(thisdtype, np.dtype) 
-            and np.issubdtype(thisdtype, np.number))
-        if is_numerical:
+        if pd.api.types.is_numeric_dtype(thisdtype):
             distArray[coord,:,:] = abs(data[col_names[coord]].to_numpy() -
                                        data[col_names[coord]].to_numpy()[:,None])
         else:

--- a/tests/test_knncmi.py
+++ b/tests/test_knncmi.py
@@ -380,13 +380,17 @@ class test_class(unittest.TestCase):
             {
                 'float':pd.Series(base).astype('float'),
                 'int':pd.Series(base).astype('int'),
+                'nullableInt':pd.Series([int(b) if b != 1 else float('nan') for b in base]).astype('Int64'), #nullable integer
                 'str':pd.Series(base).astype('string'),
                 'category':pd.Series(base).astype('category'),
+                'boolean':pd.Series([b==1 for b in base]).astype('boolean'),
             }
         )
         cmi(['int'],['float'],[],3,data)
         cmi(['int'],['str'],[],3,data)
         cmi(['int'],['category'],[],3,data)
+        cmi(['int'],['category'],['boolean'],3,data)
+        self.assertRaisesRegex(TypeError,"NAType",lambda:cmi(['nullableInt'],['category'],[],3,data))
 
 
 if __name__ == '__main__':

--- a/tests/test_knncmi.py
+++ b/tests/test_knncmi.py
@@ -370,5 +370,24 @@ class test_class(unittest.TestCase):
         out = cmi(['class'], ['swidth'], [], 3, data)
         self.assertLessEqual(out, 2 * digamma(n))
 
+    def test_dtypes(self):
+        """Check that various dtypes can be used.
+        
+        This does NOT check if the results are correct, only that the API works
+        """
+        base = [1,1,2,3,2.1,7,2,3,4,1,2,58,6,8,1,2.3]
+        data = pd.DataFrame(
+            {
+                'float':pd.Series(base).astype('float'),
+                'int':pd.Series(base).astype('int'),
+                'str':pd.Series(base).astype('string'),
+                'category':pd.Series(base).astype('category'),
+            }
+        )
+        cmi(['int'],['float'],[],3,data)
+        cmi(['int'],['str'],[],3,data)
+        cmi(['int'],['category'],[],3,data)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When passing a dataframe with columns that are not numpy dtypes, the code rases an exception instead of just treating them as categorical or doing similar clever things.

I made the  minimal effort change of changing to `pd.api.types.is_numeric_dtype`.

I also replaced the `.values` call to `to_numpy` since the pandas developers recommends that. It also made a strange bug go away, so I think it was called for.

In the test cases, I also added a check that it fails as expected when passing NAN data, instead of treating it as categorical (the user should fix this in the data, I think).